### PR TITLE
profile access experiment

### DIFF
--- a/web/modules/custom/citizen_custom/citizen_custom.module
+++ b/web/modules/custom/citizen_custom/citizen_custom.module
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\node\Entity\Node;
+use Drupal\Core\Access\AccessResult;
 
 /**
  * Implements hook_help().
@@ -563,3 +564,41 @@ function citizen_custom_preprocess_paragraph(&$variables) {
   }
 }
 
+
+function citizen_custom_node_access(\Drupal\Core\Entity\EntityInterface $entity, $operation, \Drupal\Core\Session\AccountInterface $account){
+	// ignore all permissions stuff for super users
+	if(in_array('administrator', $account->getRoles())){
+		return AccessResult::neutral();
+	}
+
+	$type = $entity->bundle();
+
+	// custom access logic for profiles (bios)
+	if($type === 'bios'){
+		// everybody can view all profiles
+		if($operation == 'view'){
+			return AccessResult::allowed();
+		}
+
+		// in this context, we're only talking about non-"view" operations
+		// such as "update" and "delete"
+
+		// site admins can edit all profiles
+		if(in_array('site_admin', $account->getRoles())){
+			return AccessResult::allowed()->cachePerPermissions();
+		}
+
+		// non-site-admins can only edit their own profile
+		// so let's make sure the profile's username matches the account's username
+		$bio_username = $entity->field_username->getString();
+		$user_username = $account->getAccountName();
+		if($bio_username === $user_username){
+			return AccessResult::allowed()->cachePerUser();
+		}else{
+			return AccessResult::forbidden()->cachePerUser();
+		}
+	}
+
+	// this means this hook has no opinion on access:
+	return AccessResult::neutral();
+}

--- a/web/modules/custom/citizen_custom/citizen_custom.module
+++ b/web/modules/custom/citizen_custom/citizen_custom.module
@@ -573,22 +573,14 @@ function citizen_custom_node_access(\Drupal\Core\Entity\EntityInterface $entity,
 
 	$type = $entity->bundle();
 
-	// custom access logic for profiles (bios)
-	if($type === 'bios'){
-		// everybody can view all profiles
-		if($operation == 'view'){
-			return AccessResult::allowed();
-		}
-
-		// in this context, we're only talking about non-"view" operations
-		// such as "update" and "delete"
-
-		// site admins can edit all profiles
+	// custom access logic for updating profiles (bios)
+	if($type === 'bios' && $operation == 'update'){
+		// site admins can update all profiles
 		if(in_array('site_admin', $account->getRoles())){
 			return AccessResult::allowed()->cachePerPermissions();
 		}
 
-		// non-site-admins can only edit their own profile
+		// non-site-admins can only update their own profile
 		// so let's make sure the profile's username matches the account's username
 		$bio_username = $entity->field_username->getString();
 		$user_username = $account->getAccountName();


### PR DESCRIPTION
This adds our access logic to profiles.

It's hard to test stuff like this, especially to test for how the cache interacts with it, but I think I've got it buttoned down.  Some scenarios I tested:

1. administrator can edit all profiles
2. site_admin can edit all profiles
3. anybody (editors and anonymous) can view all profiles
4. anybody else (aka non administrators and non site_admin users, can only edit the profile if their drupal user's "account name" (aka username) exactly matches the profile's username.
5. while logged in as an editor, I should be able to visit multiple profiles pages and see the edit tab on my own profile, and *not* see the edit tab on other profiles. I call this out specifically to test the cache; to make sure it doesn't let the user edit somebody else's profile just because the cache says they can edit their own, if that makes sense. I tested this on my local using masquerade but it might be worth it to test it on a server using actual logins to make sure the cache behaves the same way.