### PR TITLE
remove text trim on course links display

### DIFF
--- a/config/sync/core.entity_view_display.node.academic_program.default.yml
+++ b/config/sync/core.entity_view_display.node.academic_program.default.yml
@@ -431,7 +431,7 @@ third_party_settings:
                 type: link
                 label: hidden
                 settings:
-                  trim_length: 80
+                  trim_length: null
                   url_only: false
                   url_plain: false
                   rel: '0'


### PR DESCRIPTION
it was at the default 80 characters but whitney wanted it turned off