### PR TITLE
attempt to make masonry use image styles

### DIFF
--- a/web/themes/custom/citizen_dart/templates/paragraphs/gallery/paragraph--gallery.html.twig
+++ b/web/themes/custom/citizen_dart/templates/paragraphs/gallery/paragraph--gallery.html.twig
@@ -118,10 +118,11 @@
 
 					{# Render the shuffled items #}
 					{%- for itemWithClass in shuffledItems -%}
-							{% set image_id = itemWithClass.item['#paragraph'].field_image.0.target_id %}
-							<div class="masonry-item {{ itemWithClass.class }}">
-									{{ drupal_entity('media', image_id) }}
-							</div>
+						{% set image_id = itemWithClass.item['#paragraph'].field_image.0.target_id %}
+						{% set image_style = (itemWithClass.class == 'small') ? '200x200_non_crop' : '600x600_non_crop' %}
+						<div class="masonry-item {{ itemWithClass.class }}">
+							{{ drupal_entity('media', image_id, image_style) }}
+						</div>
 					{%- endfor -%}
 				{% endblock %}
 	    {% endif %}


### PR DESCRIPTION
I need a QA check on this one. This is a potential fix for [bugherd 117](https://www.bugherd.com/projects/391209/tasks/177)

I think this looks good but when I try to view the test page: http://uwec.docksal.site/academics/academic-experience/study-away

The gallery is blank, like the photos aren't loading. It looks like the img tags have the right src values though, so maybe it's just an issue with the image proxy thingy?