### PR TITLE
paragraph preview label tweak

### DIFF
--- a/web/modules/custom/citizen_custom/js/admin.js
+++ b/web/modules/custom/citizen_custom/js/admin.js
@@ -327,26 +327,13 @@
 
 	/* Add paragraph preview labels
 	----------------------- */
-	Drupal.behaviors.previewLabel = {
-		attach: function (context, settings) {
-			$(once('isParaPreview', '.lp-builder .paragraph--view-mode--preview', context)).each(function(){
-				let paragraph = this;
-
-				// these paragraph previews must be built by some other js that is trying to run at the same time.
-				// because without this setTimeout,
-				// it is unable to find the .lpb-controls-label element.
-				setTimeout(function(){
-					let labelEle = paragraph.querySelector('.lpb-controls-label');
-					if(labelEle){
-						let previewLabel = document.createElement('div');
-						previewLabel.classList.add('para-preview-label');
-						previewLabel.innerHTML = labelEle.innerHTML + ' Component';
-						paragraph.insertBefore(previewLabel, paragraph.children[0]);
-					}
-				}, 0);
-			});
-		}
-	};
+	$(document).ajaxComplete(function(){
+		// select all paragraph previews that do not already have a preview label
+		$('.lp-builder .paragraph--view-mode--preview:not(:has(.para-preview-label))').each(function(){
+			let label = $(this).find('.lpb-controls-label').html();
+			$(this).prepend('<div class="para-preview-label">'+label+' Component</div>');
+		});
+	});
 
    /* ADVANCED FILTER DRAWERS
   ----------------------- */

--- a/web/modules/custom/citizen_custom/js/admin.js
+++ b/web/modules/custom/citizen_custom/js/admin.js
@@ -242,10 +242,9 @@
   
          $(document).ajaxComplete(function () {
   
-           //when an existing whero is opened, ckeck the version and show the correct fields
+           //when an existing hero is opened, check the version and show the correct fields
            if($('.field--name-field-hero-type .js-form-type-select', this).find("option:selected").val()){
             var chosen = $('.field--name-field-hero-type .js-form-type-select', this).find("option:selected").val().replace(/_/g, '-');
-            console.log(chosen);
             if (chosen == 'image'){
               bgImageFields.hide();
               fullImageFields.hide();
@@ -326,18 +325,28 @@
   };//end cta
   
 
-  /* Add paragraph preview labels
-  ----------------------- */
-  Drupal.behaviors.previewLabel = {
-    attach: function (context, settings) {
-    	$(once('isParaPreview', '.lp-builder .paragraph--view-mode--preview', context)).each(function(){
-    		var label = $(this).attr('data-type');
-    		if (typeof label !== 'undefined') {
-	    		$(this).prepend('<div class="para-preview-label">' + label.replace(/_/g, ' ') + ' component</div>');
-	    	}
-    	});
-    }
-  };
+	/* Add paragraph preview labels
+	----------------------- */
+	Drupal.behaviors.previewLabel = {
+		attach: function (context, settings) {
+			$(once('isParaPreview', '.lp-builder .paragraph--view-mode--preview', context)).each(function(){
+				let paragraph = this;
+
+				// these paragraph previews must be built by some other js that is trying to run at the same time.
+				// because without this setTimeout,
+				// it is unable to find the .lpb-controls-label element.
+				setTimeout(function(){
+					let labelEle = paragraph.querySelector('.lpb-controls-label');
+					if(labelEle){
+						let previewLabel = document.createElement('div');
+						previewLabel.classList.add('para-preview-label');
+						previewLabel.innerHTML = labelEle.innerHTML + ' Component';
+						paragraph.insertBefore(previewLabel, paragraph.children[0]);
+					}
+				}, 0);
+			});
+		}
+	};
 
    /* ADVANCED FILTER DRAWERS
   ----------------------- */


### PR DESCRIPTION
This makes the paragraph preview js use the paragraph type's "label" rather than the machine name, to generate the preview label.