### PR TITLE
linkit links for docs link to doc media rather than file in wysiwyg

### DIFF
--- a/config/sync/core.entity_form_display.media.document.default.yml
+++ b/config/sync/core.entity_form_display.media.document.default.yml
@@ -16,14 +16,21 @@ mode: default
 content:
   field_media_file:
     type: file_generic
-    weight: 0
+    weight: 1
     region: content
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
 hidden:
   created: true
-  name: true
   path: true
   publish_on: true
   publish_state: true

--- a/config/sync/linkit.linkit_profile.wysiwyg.yml
+++ b/config/sync/linkit.linkit_profile.wysiwyg.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - file
     - node
 _core:
   default_config_hash: 32k_-pi2HTTYOivHmbwY7e5VRupTufNkVBabQu9k3nY
@@ -22,19 +21,14 @@ matchers:
       limit: 100
       include_unpublished: false
     weight: 0
-  d0611905-3b16-41b4-a70f-05577b12b3a1:
-    id: 'entity:file'
-    uuid: d0611905-3b16-41b4-a70f-05577b12b3a1
+  8b45989c-799b-471d-bc12-fa8f6446bbe5:
+    id: 'entity:media'
+    uuid: 8b45989c-799b-471d-bc12-fa8f6446bbe5
     settings:
       metadata: ''
-      bundles: null
-      group_by_bundle: null
-      substitution_type: file
+      bundles:
+        document: document
+      group_by_bundle: false
+      substitution_type: media
       limit: 100
-      file_extensions: 'txt pdf doc docx zip xls xlsx ppt pptx'
-      file_status: 1
-      images:
-        show_dimensions: false
-        show_thumbnail: false
-        thumbnail_image_style: null
     weight: 0


### PR DESCRIPTION
This is waiting on IMC to decide on what the document name field behavior should be like. If they decide the name field should exist on the document form, even though people have to type in the name of the document, then this is ready to go.