### PR TITLE
Citizen Media Files: multidev edge-purge verification (do not merge)

### DIFF
--- a/web/modules/custom/citizen_media_files/README.md
+++ b/web/modules/custom/citizen_media_files/README.md
@@ -1,0 +1,66 @@
+# Citizen Media Files
+
+Portable Electric Citizen package for the media file lifecycle: editors can
+see where media is used, replace a file while keeping its URL, and delete a
+file so it actually disappears — including from the hosting platform's edge
+cache, which is what historically made replaced and deleted files "come back"
+(files are edge-cached for up to a year by default on Acquia and Pantheon).
+
+## What it bundles
+
+- **entity_usage** — tracks where each media entity is used. Media with 0
+  usage on the current published version is safe to delete.
+- **media_entity_file_replace** — "Replace file" on the media edit form. The
+  overwrite option keeps the same filename and URL (no `-0`/`-1` suffixes).
+- **media_file_delete** — deletes the underlying file when a media entity is
+  deleted.
+- **Edge purging (this module)** — when a file is replaced or deleted, its
+  URL (and image style derivative URLs) is purged from the platform edge
+  cache, host-detected at runtime:
+  - **Acquia** (`AH_SITE_ENVIRONMENT` present): queues `url` invalidations
+    through the purge module. Requires `purge` + `acquia_purge` with the
+    site's purgers configured (Platform CDN and/or Varnish); both EC-standard
+    purgers support `url` invalidations. Processed by the site's purge
+    processors (late runtime / cron).
+  - **Pantheon** (`PANTHEON_ENVIRONMENT` present): calls
+    `pantheon_clear_edge_paths()`. If the platform ever removes that
+    function, the module logs a loud warning instead of failing silently.
+  - **Anything else** (local/DDEV, unknown host): logs what would have been
+    purged.
+
+  Force a backend for testing with `$settings['citizen_media_files_host'] =
+  'acquia'|'pantheon'|'none';` in settings.php.
+
+## Install-time defaults
+
+`hook_install()` adapts to the site instead of shipping static config:
+
+- Applies the EC baseline `entity_usage.settings` (UWEC reference config) —
+  only when the site has not already configured entity_usage.
+- Enables the "Replace file" widget on the form display of every file-backed
+  media type.
+- Grants `access entity usage statistics` and Media File Delete's permissions
+  to a `site_manager`-style role when one exists.
+- Adds a "Usage count" column (with View Usage link) to the media admin view,
+  per the UWEC reference view.
+
+Everything it could not apply safely is logged to the `citizen_media_files`
+channel — check the log after install and finish those pieces manually.
+
+## What purging cannot fix
+
+Browser caches that already hold a file (served with a long max-age before
+this module was installed), Google's index (use a Search Console removal
+request for sensitive documents), and third-party archives. Consider
+shortening the file max-age in `.htaccess` alongside this module so browsers
+re-check files at a sane interval.
+
+## Editor workflow (train clients on this)
+
+1. Check usage before deleting: media list "Usage count" column or the Usage
+   tab. 0 usage on the published version = safe.
+2. Replace: media edit form, "Replace file", keep the overwrite box checked,
+   file types must match.
+3. Delete: deleting the media entity offers to delete the file too.
+4. Sensitive removals additionally need a Google Search Console removal
+   request.

--- a/web/modules/custom/citizen_media_files/citizen_media_files.info.yml
+++ b/web/modules/custom/citizen_media_files/citizen_media_files.info.yml
@@ -1,0 +1,11 @@
+name: 'Citizen Media Files'
+type: module
+description: 'Portable media file lifecycle package: entity usage tracking, file replace, file delete, and host-aware CDN cache purging on file replace/delete.'
+package: 'Electric Citizen'
+core_version_requirement: ^10.3 || ^11
+dependencies:
+  - drupal:media
+  - drupal:file
+  - entity_usage:entity_usage
+  - media_entity_file_replace:media_entity_file_replace
+  - media_file_delete:media_file_delete

--- a/web/modules/custom/citizen_media_files/citizen_media_files.install
+++ b/web/modules/custom/citizen_media_files/citizen_media_files.install
@@ -1,0 +1,201 @@
+<?php
+
+/**
+ * @file
+ * Install-time defaults for the Citizen Media Files package.
+ *
+ * The defaults adapt to the site they land on instead of shipping static
+ * config, because media type machine names, roles, and views differ across
+ * sites. Anything that cannot be applied safely is logged rather than forced.
+ */
+
+use Drupal\media\Plugin\media\Source\File as FileSource;
+use Drupal\user\Entity\Role;
+use Drupal\views\Entity\View;
+
+/**
+ * Implements hook_install().
+ */
+function citizen_media_files_install() {
+  _citizen_media_files_apply_entity_usage_defaults();
+  _citizen_media_files_enable_replace_widgets();
+  _citizen_media_files_grant_permissions();
+  _citizen_media_files_add_usage_to_media_view();
+  // Default the "also delete the file" checkbox to checked when deleting
+  // media. An unchecked default quietly recreates the orphaned-file problem
+  // this package exists to solve; editors can still uncheck it per delete.
+  \Drupal::configFactory()->getEditable('media_file_delete.settings')
+    ->set('delete_file_default', TRUE)
+    ->save();
+  \Drupal::logger('citizen_media_files')->notice('Defaulted Media File Delete to deleting the file with the media entity.');
+}
+
+/**
+ * Applies the EC baseline entity_usage settings (UWEC reference config).
+ *
+ * Skipped when the site has already configured entity_usage, detected by the
+ * presence of a source-type list, so an existing site's tracking choices are
+ * never overwritten.
+ */
+function _citizen_media_files_apply_entity_usage_defaults() {
+  $logger = \Drupal::logger('citizen_media_files');
+  $config = \Drupal::configFactory()->getEditable('entity_usage.settings');
+  // Only apply the baseline when the stored config is byte-identical to
+  // entity_usage's shipped install defaults. Any deviation at all means the
+  // site made choices (which can be as subtle as a local-task or warning
+  // list, with no tracking lists present — seen on ec2025), and those are
+  // never overwritten.
+  $shipped = [
+    'track_enabled_base_fields' => FALSE,
+    'local_task_enabled_entity_types' => [],
+    'usage_controller_items_per_page' => 25,
+  ];
+  $data = $config->getRawData();
+  unset($data['_core']);
+  if ($data != $shipped) {
+    $logger->notice('entity_usage is already configured on this site; leaving its settings untouched. Compare them against the EC baseline (UWEC) manually.');
+    return;
+  }
+  $config
+    ->set('local_task_enabled_entity_types', ['media', 'node'])
+    ->set('track_enabled_source_entity_types', ['block_content', 'node', 'paragraph'])
+    ->set('track_enabled_target_entity_types', ['media', 'node'])
+    ->set('track_enabled_plugins', [
+      'dynamic_entity_reference',
+      'entity_embed',
+      'entity_reference',
+      'html_link',
+      'link',
+      'linkit',
+      'media_embed',
+    ])
+    ->set('track_enabled_base_fields', FALSE)
+    ->set('delete_warning_message_entity_types', ['media'])
+    ->set('usage_controller_items_per_page', 25)
+    ->save();
+  $logger->notice('Applied EC baseline entity_usage settings.');
+}
+
+/**
+ * Enables the MEFR "Replace file" widget on every file-backed media type.
+ */
+function _citizen_media_files_enable_replace_widgets() {
+  $logger = \Drupal::logger('citizen_media_files');
+  $display_repository = \Drupal::service('entity_display.repository');
+  $types = \Drupal::entityTypeManager()->getStorage('media_type')->loadMultiple();
+  foreach ($types as $type) {
+    /** @var \Drupal\media\MediaTypeInterface $type */
+    if (!$type->getSource() instanceof FileSource) {
+      continue;
+    }
+    $form_display = $display_repository->getFormDisplay('media', $type->id(), 'default');
+    if ($form_display->getComponent('replace_file')) {
+      continue;
+    }
+    // A display whose STORED config lists replace_file as hidden was saved
+    // with that choice (seen on UWEC); respect it rather than overriding site
+    // configuration. The stored config must be read directly — the loaded
+    // display entity computes default-hidden extra fields into its hidden
+    // list at runtime, which false-positives on every fresh site (seen on
+    // ecsupport).
+    $stored_hidden = \Drupal::config('core.entity_form_display.media.' . $type->id() . '.default')->get('hidden') ?? [];
+    if (isset($stored_hidden['replace_file'])) {
+      $logger->notice('The @type media form explicitly hides the Replace file widget; leaving it hidden.', ['@type' => $type->id()]);
+      continue;
+    }
+    $form_display->setComponent('replace_file', ['weight' => 3, 'region' => 'content']);
+    $form_display->save();
+    $logger->notice('Enabled the Replace file widget on the @type media form.', ['@type' => $type->id()]);
+  }
+}
+
+/**
+ * Grants package permissions to a site-manager-style role when one exists.
+ *
+ * Only permissions defined by the bundled modules are granted. File replace
+ * needs no permission of its own (it follows media update access), and file
+ * delete access is granted per Media File Delete's permission set when
+ * present.
+ */
+function _citizen_media_files_grant_permissions() {
+  $logger = \Drupal::logger('citizen_media_files');
+  $role = NULL;
+  foreach (['site_manager', 'site_admin', 'manager'] as $candidate) {
+    if ($role = Role::load($candidate)) {
+      break;
+    }
+  }
+  if (!$role) {
+    $logger->warning('No site-manager-style role found (looked for site_manager, site_admin, manager). Grant "access entity usage statistics" and the Media File Delete permissions manually.');
+    return;
+  }
+  $defined = \Drupal::service('user.permissions')->getPermissions();
+  // "delete any file" is what lets Media File Delete's checkbox delete files
+  // the user does not own (its access handler grants file delete on it). The
+  // module's "administer media file delete" settings permission is
+  // deliberately NOT granted.
+  $wanted = ['access entity usage statistics', 'delete any file'];
+  $granted = [];
+  foreach ($wanted as $name) {
+    if (isset($defined[$name]) && !$role->hasPermission($name)) {
+      $role->grantPermission($name);
+      $granted[] = $name;
+    }
+  }
+  if ($granted) {
+    $role->save();
+    $logger->notice('Granted to role @role: @perms', [
+      '@role' => $role->id(),
+      '@perms' => implode(', ', $granted),
+    ]);
+  }
+}
+
+/**
+ * Adds a "Usage count" column to the media admin view.
+ *
+ * Uses the module's own non-SQL views field (count + View Usage link,
+ * mirroring the UWEC reference column's presentation) rather than the UWEC
+ * relationship/aggregation recipe, which only works on views built for
+ * aggregation. Skipped with a log message when the view is missing or already
+ * carries a usage column (either the native entity_usage relationship or this
+ * module's field).
+ */
+function _citizen_media_files_add_usage_to_media_view() {
+  $logger = \Drupal::logger('citizen_media_files');
+  $view = View::load('media');
+  if (!$view) {
+    $logger->warning('No views.view.media found; add the entity_usage count column to your media listing manually.');
+    return;
+  }
+  $display = &$view->getDisplay('default');
+  if (isset($display['display_options']['relationships']['media_to_usage_entity'])) {
+    $logger->notice('The media view already has the entity_usage relationship; leaving it untouched.');
+    return;
+  }
+  if (isset($display['display_options']['fields']['citizen_media_files_usage_count'])) {
+    $logger->notice('The media view already has the usage count field; leaving it untouched.');
+    return;
+  }
+  try {
+    // The module's own non-SQL field plugin: adds no relationship, join, or
+    // aggregation, so it cannot break the host view's query. Never inject
+    // views aggregation into an existing view — flipping group_by on ec2025's
+    // media view produced malformed SQL from a file field that does not
+    // aggregate.
+    $display['display_options']['fields']['citizen_media_files_usage_count'] = [
+      'id' => 'citizen_media_files_usage_count',
+      'table' => 'media',
+      'field' => 'citizen_media_files_usage_count',
+      'relationship' => 'none',
+      'plugin_id' => 'citizen_media_files_usage_count',
+      'label' => 'Usage count',
+      'exclude' => FALSE,
+    ];
+    $view->save();
+    $logger->notice('Added the "Usage count" column to the media admin view.');
+  }
+  catch (\Exception $e) {
+    $logger->error('Could not add the usage column to the media view: @message. Add the "Usage count (Citizen Media Files)" field manually.', ['@message' => $e->getMessage()]);
+  }
+}

--- a/web/modules/custom/citizen_media_files/citizen_media_files.module
+++ b/web/modules/custom/citizen_media_files/citizen_media_files.module
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * @file
+ * Media file lifecycle: edge cache purging on file replace and delete.
+ */
+
+use Drupal\file\FileInterface;
+
+/**
+ * Implements hook_views_data_alter().
+ *
+ * Exposes the self-contained usage count field on media views.
+ */
+function citizen_media_files_views_data_alter(array &$data) {
+  $data['media']['citizen_media_files_usage_count'] = [
+    'title' => t('Usage count (Citizen Media Files)'),
+    'help' => t('Number of places this media item is used, with a link to the full usage list. Adds nothing to the view query.'),
+    'field' => [
+      'id' => 'citizen_media_files_usage_count',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_module_preuninstall().
+ *
+ * Strips this module's usage count field out of any view before the config
+ * system's dependency cascade runs. Without this, uninstalling the module
+ * DELETES every view carrying the field (the whole media admin view, not
+ * just the column) — confirmed on ecsupport.
+ */
+function citizen_media_files_module_preuninstall($module) {
+  if ($module !== 'citizen_media_files') {
+    return;
+  }
+  foreach (\Drupal::entityTypeManager()->getStorage('view')->loadMultiple() as $view) {
+    $changed = FALSE;
+    $displays = $view->get('display');
+    foreach ($displays as &$display) {
+      if (isset($display['display_options']['fields']['citizen_media_files_usage_count'])) {
+        unset($display['display_options']['fields']['citizen_media_files_usage_count']);
+        $changed = TRUE;
+      }
+    }
+    unset($display);
+    if ($changed) {
+      $view->set('display', $displays);
+      $view->save();
+      \Drupal::logger('citizen_media_files')->notice('Removed the usage count field from the @view view before uninstall.', ['@view' => $view->id()]);
+    }
+  }
+}
+
+/**
+ * Implements hook_file_update().
+ *
+ * Fires when a file entity is re-saved, which includes Media Entity File
+ * Replace overwriting a file's contents in place (same URI, same URL). The
+ * edge cache still holds the old contents at that URL, so purge it.
+ */
+function citizen_media_files_file_update(FileInterface $file) {
+  if ($file->isPermanent()) {
+    \Drupal::service('citizen_media_files.edge_purger')->purgeFile($file, 'file updated/replaced');
+  }
+}
+
+/**
+ * Implements hook_file_delete().
+ *
+ * Fires when a file entity is deleted, including deletions triggered by
+ * Media File Delete when a media entity and its file are removed together.
+ */
+function citizen_media_files_file_delete(FileInterface $file) {
+  \Drupal::service('citizen_media_files.edge_purger')->purgeFile($file, 'file deleted');
+}

--- a/web/modules/custom/citizen_media_files/citizen_media_files.services.yml
+++ b/web/modules/custom/citizen_media_files/citizen_media_files.services.yml
@@ -1,0 +1,17 @@
+services:
+  logger.channel.citizen_media_files:
+    parent: logger.channel_base
+    arguments: ['citizen_media_files']
+
+  citizen_media_files.host_detector:
+    class: Drupal\citizen_media_files\HostDetector
+    arguments: ['@settings']
+
+  citizen_media_files.edge_purger:
+    class: Drupal\citizen_media_files\EdgePurger
+    arguments:
+      - '@citizen_media_files.host_detector'
+      - '@logger.channel.citizen_media_files'
+      - '@file_url_generator'
+      - '@entity_type.manager'
+      - '@settings'

--- a/web/modules/custom/citizen_media_files/composer.json
+++ b/web/modules/custom/citizen_media_files/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "electriccitizen/citizen_media_files",
+    "description": "Portable media file lifecycle package: entity usage tracking, file replace, file delete, and host-aware CDN cache purging on file replace/delete.",
+    "type": "drupal-custom-module",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/entity_usage": "^2.0@beta",
+        "drupal/media_entity_file_replace": "^1.3",
+        "drupal/media_file_delete": "^1.3"
+    },
+    "suggest": {
+        "drupal/purge": "Required on Acquia-hosted sites for edge purging (with drupal/acquia_purge).",
+        "drupal/acquia_purge": "Required on Acquia-hosted sites for edge purging."
+    }
+}

--- a/web/modules/custom/citizen_media_files/src/EdgePurger.php
+++ b/web/modules/custom/citizen_media_files/src/EdgePurger.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace Drupal\citizen_media_files;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Site\Settings;
+use Drupal\file\FileInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Purges file URLs from the hosting platform's edge cache.
+ *
+ * Host support:
+ * - Acquia: queues "url" invalidations through the purge module, which the
+ *   site's configured purgers (Acquia Platform CDN and/or Varnish) process.
+ * - Pantheon: calls pantheon_clear_edge_paths(), provided by the platform.
+ * - Anything else (including local): logs what would have been purged.
+ */
+class EdgePurger {
+
+  /**
+   * Host detector.
+   *
+   * @var \Drupal\citizen_media_files\HostDetector
+   */
+  protected $hostDetector;
+
+  /**
+   * Module logger channel.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * File URL generator.
+   *
+   * @var \Drupal\Core\File\FileUrlGeneratorInterface
+   */
+  protected $fileUrlGenerator;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Site settings.
+   *
+   * @var \Drupal\Core\Site\Settings
+   */
+  protected $settings;
+
+  /**
+   * Constructs the purger.
+   */
+  public function __construct(HostDetector $host_detector, LoggerInterface $logger, FileUrlGeneratorInterface $file_url_generator, EntityTypeManagerInterface $entity_type_manager, Settings $settings) {
+    $this->hostDetector = $host_detector;
+    $this->logger = $logger;
+    $this->fileUrlGenerator = $file_url_generator;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->settings = $settings;
+  }
+
+  /**
+   * Purges a file's URL (and any image style derivatives) from the edge.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The file whose URLs should be purged.
+   * @param string $reason
+   *   Short human-readable trigger description, used in log messages.
+   */
+  public function purgeFile(FileInterface $file, string $reason = 'file change'): void {
+    $uri = $file->getFileUri();
+    // Only public files are served through the edge cache.
+    if (!str_starts_with((string) $uri, 'public://')) {
+      return;
+    }
+    $urls = $this->expandUrls($this->collectUrls($file));
+    if (!$urls) {
+      return;
+    }
+    switch ($this->hostDetector->getHost()) {
+      case HostDetector::ACQUIA:
+        $this->purgeAcquia($urls, $reason);
+        break;
+
+      case HostDetector::PANTHEON:
+        $this->purgePantheon($urls, $reason);
+        break;
+
+      default:
+        $this->logger->info('No edge cache host detected; would purge (@reason): @urls', [
+          '@reason' => $reason,
+          '@urls' => $this->summarizeUrls($urls),
+        ]);
+    }
+  }
+
+  /**
+   * Builds the absolute URLs for a file, including image style derivatives.
+   *
+   * @param \Drupal\file\FileInterface $file
+   *   The file.
+   *
+   * @return string[]
+   *   Absolute URLs.
+   */
+  protected function collectUrls(FileInterface $file): array {
+    $uri = $file->getFileUri();
+    $urls = [$this->fileUrlGenerator->generateAbsoluteString($uri)];
+    // Image derivatives live at their own edge-cached URLs. Only include
+    // derivatives that actually exist on disk: a style that was never
+    // generated was never served, and sites carry 100+ styles. Both MEFR
+    // (which flushes derivatives AFTER the file entity save that triggers
+    // this) and file deletion (image module's flush hook runs after ours,
+    // by module name order) leave derivatives on disk at hook time.
+    if (str_starts_with((string) $file->getMimeType(), 'image/')) {
+      try {
+        $styles = $this->entityTypeManager->getStorage('image_style')->loadMultiple();
+        foreach ($styles as $style) {
+          /** @var \Drupal\image\ImageStyleInterface $style */
+          if ($style->supportsUri($uri) && file_exists($style->buildUri($uri))) {
+            $urls[] = $style->buildUrl($uri);
+          }
+        }
+      }
+      catch (\Exception $e) {
+        $this->logger->warning('Could not build image style URLs for @uri: @message', [
+          '@uri' => $uri,
+          '@message' => $e->getMessage(),
+        ]);
+      }
+    }
+    return array_unique($urls);
+  }
+
+  /**
+   * Queues URL invalidations through the purge module on Acquia.
+   *
+   * @param string[] $urls
+   *   Absolute URLs to purge.
+   * @param string $reason
+   *   Trigger description for logging.
+   */
+  protected function purgeAcquia(array $urls, string $reason): void {
+    // The purge module is an optional dependency (absent on Pantheon sites),
+    // so its services cannot be constructor-injected here.
+    // phpcs:ignore DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
+    $container = \Drupal::getContainer();
+    if (!$container->has('purge.invalidation.factory') || !$container->has('purge.queue') || !$container->has('purge.queuers')) {
+      $this->logger->warning('Acquia host detected but the purge module is not available; NOT purged (@reason): @urls', [
+        '@reason' => $reason,
+        '@urls' => $this->summarizeUrls($urls),
+      ]);
+      return;
+    }
+    try {
+      $queuer = $container->get('purge.queuers')->get('citizen_media_files');
+      if (!$queuer) {
+        $this->logger->warning('The citizen_media_files purge queuer is not enabled; NOT purged: @urls', [
+          '@urls' => $this->summarizeUrls($urls),
+        ]);
+        return;
+      }
+      $factory = $container->get('purge.invalidation.factory');
+      $invalidations = [];
+      foreach ($urls as $url) {
+        $invalidations[] = $factory->get('url', $url);
+      }
+      $container->get('purge.queue')->add($queuer, $invalidations);
+      $this->logger->notice('Queued @count edge purge(s) (@reason): @urls', [
+        '@count' => count($invalidations),
+        '@reason' => $reason,
+        '@urls' => $this->summarizeUrls($urls),
+      ]);
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Failed to queue edge purges (@reason): @class @message. URLs not purged: @urls', [
+        '@reason' => $reason,
+        '@class' => get_class($e),
+        '@message' => $e->getMessage(),
+        '@urls' => $this->summarizeUrls($urls),
+      ]);
+    }
+  }
+
+  /**
+   * Clears edge paths via Pantheon's platform function.
+   *
+   * @param string[] $urls
+   *   Absolute URLs to purge.
+   * @param string $reason
+   *   Trigger description for logging.
+   */
+  protected function purgePantheon(array $urls, string $reason): void {
+    if (!function_exists('pantheon_clear_edge_paths')) {
+      $this->logger->warning('Pantheon host detected but pantheon_clear_edge_paths() is unavailable; NOT purged (@reason): @urls. The platform API may have changed.', [
+        '@reason' => $reason,
+        '@urls' => $this->summarizeUrls($urls),
+      ]);
+      return;
+    }
+    $paths = [];
+    foreach ($urls as $url) {
+      $parts = parse_url($url);
+      $path = $parts['path'] ?? '';
+      if (!empty($parts['query'])) {
+        $path .= '?' . $parts['query'];
+      }
+      if ($path) {
+        $paths[] = $path;
+      }
+    }
+    try {
+      // Pantheon caps how many paths one call accepts; chunk defensively.
+      foreach (array_chunk($paths, 25) as $chunk) {
+        pantheon_clear_edge_paths($chunk);
+      }
+      $this->logger->notice('Cleared @count Pantheon edge path(s) (@reason): @paths', [
+        '@count' => count($paths),
+        '@reason' => $reason,
+        '@paths' => $this->summarizeUrls($paths),
+      ]);
+    }
+    catch (\Exception $e) {
+      $this->logger->error('Pantheon edge clear failed (@reason): @message', [
+        '@reason' => $reason,
+        '@message' => $e->getMessage(),
+      ]);
+    }
+  }
+
+  /**
+   * Expands each URL across the site's real public base URLs.
+   *
+   * Varnish caches per scheme and host, so a purge only clears the exact
+   * variant it names. URLs generated in CLI/cron context come out http:// —
+   * purging that clears a redirect object while the real https:// file object
+   * survives (confirmed on Acquia dev) — and multi-domain sites cache a copy
+   * per domain. Sites list their public base URLs in settings.php:
+   *
+   * @code
+   * $settings['citizen_media_files_base_urls'] = [
+   *   'https://dcyf.mn.gov',
+   *   'https://mndcyfprod.prod.acquia-sites.com',
+   * ];
+   * @endcode
+   *
+   * Without the setting, the generated URL's host is kept and the scheme is
+   * forced to https.
+   *
+   * @param string[] $urls
+   *   Absolute URLs as generated.
+   *
+   * @return string[]
+   *   URLs expanded across base URLs.
+   */
+  protected function expandUrls(array $urls): array {
+    $bases = $this->settings->get('citizen_media_files_base_urls') ?: [];
+    $out = [];
+    foreach ($urls as $url) {
+      $parts = parse_url($url);
+      $path_query = ($parts['path'] ?? '') . (isset($parts['query']) ? '?' . $parts['query'] : '');
+      if ($bases) {
+        foreach ($bases as $base) {
+          $out[] = rtrim($base, '/') . $path_query;
+        }
+      }
+      else {
+        $host = ($parts['host'] ?? '') . (isset($parts['port']) ? ':' . $parts['port'] : '');
+        $out[] = 'https://' . $host . $path_query;
+      }
+    }
+    return array_unique($out);
+  }
+
+  /**
+   * Renders a URL list for logging without flooding the log.
+   *
+   * @param string[] $urls
+   *   URLs or paths.
+   *
+   * @return string
+   *   The first few entries plus a count of the rest.
+   */
+  protected function summarizeUrls(array $urls): string {
+    $shown = array_slice($urls, 0, 5);
+    $rest = count($urls) - count($shown);
+    $summary = implode(', ', $shown);
+    if ($rest > 0) {
+      $summary .= " (+ $rest more)";
+    }
+    return $summary;
+  }
+
+}

--- a/web/modules/custom/citizen_media_files/src/HostDetector.php
+++ b/web/modules/custom/citizen_media_files/src/HostDetector.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\citizen_media_files;
+
+use Drupal\Core\Site\Settings;
+
+/**
+ * Detects which hosting platform the site is running on.
+ */
+class HostDetector {
+
+  const ACQUIA = 'acquia';
+  const PANTHEON = 'pantheon';
+  const NONE = 'none';
+
+  /**
+   * Site settings.
+   *
+   * @var \Drupal\Core\Site\Settings
+   */
+  protected $settings;
+
+  /**
+   * Constructs the host detector.
+   *
+   * @param \Drupal\Core\Site\Settings $settings
+   *   Site settings.
+   */
+  public function __construct(Settings $settings) {
+    $this->settings = $settings;
+  }
+
+  /**
+   * Returns the detected host platform.
+   *
+   * A `citizen_media_files_host` entry in settings.php overrides detection,
+   * which allows forcing a backend for testing.
+   *
+   * @return string
+   *   One of the ACQUIA, PANTHEON, or NONE constants.
+   */
+  public function getHost(): string {
+    $override = $this->settings->get('citizen_media_files_host');
+    if (in_array($override, [self::ACQUIA, self::PANTHEON, self::NONE], TRUE)) {
+      return $override;
+    }
+    if (getenv('AH_SITE_ENVIRONMENT') !== FALSE) {
+      return self::ACQUIA;
+    }
+    if (getenv('PANTHEON_ENVIRONMENT') !== FALSE) {
+      return self::PANTHEON;
+    }
+    return self::NONE;
+  }
+
+}

--- a/web/modules/custom/citizen_media_files/src/Plugin/Purge/Queuer/MediaFilesQueuer.php
+++ b/web/modules/custom/citizen_media_files/src/Plugin/Purge/Queuer/MediaFilesQueuer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Drupal\citizen_media_files\Plugin\Purge\Queuer;
+
+use Drupal\purge\Plugin\Purge\Queuer\QueuerBase;
+use Drupal\purge\Plugin\Purge\Queuer\QueuerInterface;
+
+/**
+ * Queues file URL invalidations when media files are replaced or deleted.
+ *
+ * @PurgeQueuer(
+ *   id = "citizen_media_files",
+ *   label = @Translation("Citizen Media Files"),
+ *   description = @Translation("Queues edge cache purges for file URLs when files are replaced or deleted."),
+ *   enable_by_default = true,
+ *   configform = "",
+ * )
+ */
+class MediaFilesQueuer extends QueuerBase implements QueuerInterface {
+
+}

--- a/web/modules/custom/citizen_media_files/src/Plugin/views/field/MediaUsageCount.php
+++ b/web/modules/custom/citizen_media_files/src/Plugin/views/field/MediaUsageCount.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\citizen_media_files\Plugin\views\field;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Url;
+use Drupal\entity_usage\EntityUsageInterface;
+use Drupal\views\Plugin\views\field\FieldPluginBase;
+use Drupal\views\ResultRow;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Usage count for a media row, computed via the entity_usage service.
+ *
+ * Deliberately a non-SQL field: it adds no relationship, no join, and no
+ * aggregation to the host view, so it cannot break an existing view's query
+ * the way retrofitting views aggregation can (a group_by flipped on an
+ * arbitrary media view produced malformed SQL on ec2025).
+ *
+ * @ViewsField("citizen_media_files_usage_count")
+ */
+class MediaUsageCount extends FieldPluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity usage service.
+   *
+   * @var \Drupal\entity_usage\EntityUsageInterface
+   */
+  protected $entityUsage;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+    $instance->entityUsage = $container->get('entity_usage.usage');
+    return $instance;
+  }
+
+  /**
+   * Constructs the plugin.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ?EntityUsageInterface $entity_usage = NULL) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    if ($entity_usage) {
+      $this->entityUsage = $entity_usage;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function query() {
+    // Non-SQL field: nothing to add to the view query.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(ResultRow $values) {
+    $entity = $this->getEntity($values);
+    if (!$entity) {
+      return '';
+    }
+    $count = 0;
+    foreach ($this->entityUsage->listSources($entity) as $sources) {
+      foreach ($sources as $records) {
+        $count += is_array($records) ? count($records) : 1;
+      }
+    }
+    $url = Url::fromRoute('entity_usage.usage_list', [
+      'entity_type' => $entity->getEntityTypeId(),
+      'entity_id' => $entity->id(),
+    ]);
+    return [
+      '#type' => 'inline_template',
+      '#template' => '<div>{{ count }}</div><a href="{{ url }}" target="_blank">{% trans %}View Usage{% endtrans %}</a>',
+      '#context' => [
+        'count' => $count,
+        'url' => $url->toString(),
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## Summary
- Adds the portable citizen_media_files package (entity usage + file replace + file delete + host-aware CDN purge) to a test branch so CI builds a multidev for verifying pantheon_clear_edge_paths() against the real Pantheon Global CDN.
- UWEC already carries all three contrib dependencies, so this adds custom module code only; no composer or config changes.
- Do not merge: this branch exists to build the multidev. Rollout to UWEC, if wanted, is a separate decision.

## Test plan
- [x] Local install/uninstall verified on UWEC (widgets, permissions, view field, uninstall safety)
- [ ] Edge purge verified on the multidev (file replace serves fresh content, delete returns 404)